### PR TITLE
Explicit casting

### DIFF
--- a/Tune-O-Matic.ino
+++ b/Tune-O-Matic.ino
@@ -46,7 +46,7 @@
 */
 
 // uncomment to activate serial output and LEDs test patterns
-//#define DEBUG
+#define DEBUG
 
 // uncomment the corresponding 7-segment display
 #define COMMON_ANODE
@@ -84,10 +84,10 @@ byte newData  = 0;
 byte prevData = 0;
 
 // Freq variables.
-uint16_t period = 0;
+uint32_t period = 0;
 uint32_t averaged_period = 0;
 
-uint16_t frequency = 0;
+uint32_t frequency = 0;
 
 #define HALF_SAMPLE_VALUE 127
 
@@ -156,7 +156,7 @@ ISR(ADC_vect) {       // When new ADC value ready.
           totalTimer += timer[i];
         }
 
-        period = totalTimer * 100 ; // Set period. and increase resolution
+        period = (uint32_t)totalTimer * 100 ; // Set period. and increase resolution
 
         // moving average
         averaged_period = period + averaged_period - ((averaged_period - 8) >> 4);
@@ -476,7 +476,7 @@ void setup() {
 
 
 #ifdef DEBUG
-  Serial.begin(9600);
+  Serial.begin(115200);
 
   test_digits(200);  // run some LEDs showcase
 
@@ -506,7 +506,6 @@ void setup() {
 
   sei(); // Enable interrupts.
 }
-
 
 void loop() {
   frequency = (TIMER_RATE_10 * 100) / (averaged_period >> 4); // Timer rate with an extra zero/period.
@@ -584,6 +583,8 @@ void loop() {
   }
 
 #ifdef DEBUG
+  Serial.print(period);
+  Serial.print(F(" "));
   Serial.print(averaged_period >> 4);
   Serial.print(F(" "));
   Serial.print(frequency);

--- a/Tune-O-Matic.ino
+++ b/Tune-O-Matic.ino
@@ -46,7 +46,7 @@
 */
 
 // uncomment to activate serial output and LEDs test patterns
-#define DEBUG
+//#define DEBUG
 
 // uncomment the corresponding 7-segment display
 #define COMMON_ANODE


### PR DESCRIPTION
Bug fix: was unable to read frequencies below 60Hz.

Variable 'period' was 16bit. This resulted in an overflow when frequency was below 60Hz.